### PR TITLE
fix: reloading the config now also removes pets from the list

### DIFF
--- a/src/npc_beastmaster.cpp
+++ b/src/npc_beastmaster.cpp
@@ -368,6 +368,11 @@ public:
             BeastMasterMinLevel = 10;
         }
 
+        pets.clear();
+        exoticPets.clear();
+        rarePets.clear();
+        rareExoticPets.clear();
+
         LoadPets(sConfigMgr->GetStringDefault("BeastMaster.Pets", ""), pets);
         LoadPets(sConfigMgr->GetStringDefault("BeastMaster.ExoticPets", ""), exoticPets);
         LoadPets(sConfigMgr->GetStringDefault("BeastMaster.RarePets", ""), rarePets);


### PR DESCRIPTION
I forgot in PR #17 to clear the maps when reloading the config in order to also be able to remove pets from the list dynamically. This PR fixes this.

Tested build and in-game.