### PR TITLE
chore(PCH): remove "ScriptPCH.h"

### DIFF
--- a/src/npc_beastmaster.cpp
+++ b/src/npc_beastmaster.cpp
@@ -1,7 +1,8 @@
+#include "ScriptMgr.h"
+#include "Player.h"
+#include "Chat.h"
 #include "Config.h"
 #include "Pet.h"
-#include "ScriptPCH.h"
-#include "Configuration/Config.h"
 #include "ScriptedGossip.h"
 
 std::vector<uint32> HunterSpells = { 883, 982, 2641, 6991, 48990, 1002, 1462, 6197 };


### PR DESCRIPTION
"ScriptPCH.h" is intended to be used for pre-compiling headers, it should not be included directly because it hides the actual dependencies. It's sole purpose is to be used as a tool to reduce compilation time, either through config.sh or cmake:

config.sh:
```CSCRIPTPCH```

cmake:
```-DUSE_SCRIPTPCH```

Tested on Ubuntu 16.04