### PR TITLE
fix(CreatureScript/Spell): Use correct "CreatedBySpell" for the pets

### DIFF
--- a/conf/npc_beastmaster.conf.dist
+++ b/conf/npc_beastmaster.conf.dist
@@ -17,10 +17,6 @@ BeastMaster.Announce = 1
 
 BeastMaster.HunterOnly = 0
 
-# Is the core Pet.cpp modified? (default: 0)
-
-BeastMaster.CorePatch = 0
-
 # Required level to adopt pets. (default: 10, 0 = disable)
 
 BeastMaster.MinLevel = 10

--- a/src/npc_beastmaster.cpp
+++ b/src/npc_beastmaster.cpp
@@ -36,6 +36,7 @@ enum PetGossip
 enum PetSpells
 {
     PET_SPELL_CALL_PET      =     883,
+    PET_SPELL_TAME_BEAST    =   13481,
     PET_SPELL_BEAST_MASTERY =   53270,
     PET_MAX_HAPPINESS       = 1048000
 };
@@ -295,7 +296,7 @@ private:
         }
 
         // Create Tamed Creature
-        Pet* pet = player->CreateTamedPetFrom(entry - PET_PAGE_MAX, PET_SPELL_CALL_PET);
+        Pet* pet = player->CreateTamedPetFrom(entry - PET_PAGE_MAX, PET_SPELL_TAME_BEAST);
         if (!pet) { return; }
 
         // Set Pet Happiness

--- a/src/npc_beastmaster.cpp
+++ b/src/npc_beastmaster.cpp
@@ -15,7 +15,6 @@ bool BeastMasterAnnounceToPlayer;
 bool BeastMasterHunterOnly;
 bool BeastMasterAllowExotic;
 bool BeastMasterKeepPetHappy;
-bool BeastMasterCorePatch;
 uint32 BeastMasterMinLevel;
 bool BeastMasterHunterBeastMasteryRequired;
 
@@ -374,7 +373,6 @@ public:
         BeastMasterHunterOnly = sConfigMgr->GetBoolDefault("BeastMaster.HunterOnly", true);
         BeastMasterAllowExotic = sConfigMgr->GetBoolDefault("BeastMaster.AllowExotic", true);
         BeastMasterKeepPetHappy = sConfigMgr->GetBoolDefault("BeastMaster.KeepPetHappy", false);
-        BeastMasterCorePatch = sConfigMgr->GetBoolDefault("BeastMaster.CorePatch", false);
         BeastMasterMinLevel = sConfigMgr->GetIntDefault("BeastMaster.MinLevel", 10);
         BeastMasterHunterBeastMasteryRequired = sConfigMgr->GetIntDefault("BeastMaster.HunterBeastMasteryRequired", false);
 
@@ -431,10 +429,7 @@ class BeastMaster_PlayerScript : public PlayerScript
         // Announce Module
         if (BeastMasterAnnounceToPlayer)
         {
-            if (BeastMasterCorePatch)
-                ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00BeastMasterNPC |rmodule with core patch.");
-            else
-                ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00BeastMasterNPC |rmodule without core patch.");
+            ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00BeastMasterNPC |rmodule.");
         }
     }
 


### PR DESCRIPTION
- Use "Tame Beast" (13481) instead of "Call Pet" (883) for the "CreatedBySpell" attribute of the pets.
- Remove BeastMaster.CorePatch, as it is not used anymore