### PR TITLE
fix(CreatureScript/Spell): Use different "CreatedBySpell" for the pets of hunters and non-hunters

### DIFF
--- a/src/npc_beastmaster.cpp
+++ b/src/npc_beastmaster.cpp
@@ -295,7 +295,7 @@ private:
         }
 
         // Create Tamed Creature
-        Pet* pet = player->CreateTamedPetFrom(entry - PET_PAGE_MAX, PET_SPELL_TAME_BEAST);
+        Pet* pet = player->CreateTamedPetFrom(entry - PET_PAGE_MAX, player->getClass() == CLASS_HUNTER ? PET_SPELL_TAME_BEAST : PET_SPELL_CALL_PET);
         if (!pet) { return; }
 
         // Set Pet Happiness


### PR DESCRIPTION
Fix a bug I introduced with commit b3da783: Use "Tame Beast" for hunters and "Call Pet" for non-hunters, as they cannot use "Tame Beast".