### PR TITLE
fix: resolve action ID collisions, spell retention on login, and hook registration

### DIFF
--- a/src/NpcBeastmaster.cpp
+++ b/src/NpcBeastmaster.cpp
@@ -97,6 +97,7 @@ enum PetGossip {
   PET_PAGE_START_RARE_PETS = 701,
   PET_PAGE_START_RARE_EXOTIC_PETS = 801,
   PET_PAGE_MAX = 901,
+  PET_CREATE_OFFSET = 100000,
   PET_MAIN_MENU = 50,
   PET_REMOVE_SKILLS = 80,
   PET_GOSSIP_HELLO = 601026,
@@ -657,7 +658,7 @@ void NpcBeastmaster::GossipSelect(Player *player, Creature *creature,
     return;
   }
 
-  if (action >= PET_PAGE_MAX)
+  if (action >= PET_CREATE_OFFSET)
     CreatePet(player, creature, action);
 }
 
@@ -666,7 +667,7 @@ void NpcBeastmaster::CreatePet(Player *player, Creature *creature,
   if (!sConfigMgr->GetOption<bool>("BeastMaster.Enable", true))
     return;
 
-  uint32 petEntry = action - PET_PAGE_MAX;
+  uint32 petEntry = action - PET_CREATE_OFFSET;
   const PetInfo *info = FindPetInfo(petEntry);
 
   if (player->IsExistPet()) {
@@ -763,7 +764,7 @@ void NpcBeastmaster::AddPetsToGossip(Player *player,
                          0); // 0 = no action
       } else {
         AddGossipItemFor(player, pet.icon, pet.name, GOSSIP_SENDER_MAIN,
-                         pet.entry + PET_PAGE_MAX);
+                         pet.entry + PET_CREATE_OFFSET);
       }
     }
     count++;

--- a/src/NpcBeastmaster.cpp
+++ b/src/NpcBeastmaster.cpp
@@ -1080,9 +1080,9 @@ bool BeastMaster_CommandScript::HandleBeastmasterCommand(
 class BeastmasterLoginNotice_PlayerScript : public PlayerScript {
 public:
   BeastmasterLoginNotice_PlayerScript()
-      : PlayerScript("BeastmasterLoginNotice_PlayerScript") {}
+      : PlayerScript("BeastmasterLoginNotice_PlayerScript", {PLAYERHOOK_ON_LOGIN}) {}
 
-  void OnLogin(Player *player) override {
+  void OnPlayerLogin(Player *player) override {
     if (sConfigMgr->GetOption<bool>("BeastMaster.Enable", true)) {
       // Fix for non-hunters losing pet spells on login due to core spell validation
       if (player->getClass() != CLASS_HUNTER) {

--- a/src/NpcBeastmaster.cpp
+++ b/src/NpcBeastmaster.cpp
@@ -1082,7 +1082,44 @@ public:
   BeastmasterLoginNotice_PlayerScript()
       : PlayerScript("BeastmasterLoginNotice_PlayerScript") {}
 
-  void OnLogin(Player *player) {
+  void OnLogin(Player *player) override {
+    if (sConfigMgr->GetOption<bool>("BeastMaster.Enable", true)) {
+      // Fix for non-hunters losing pet spells on login due to core spell validation
+      if (player->getClass() != CLASS_HUNTER) {
+        QueryResult res = CharacterDatabase.Query(
+            "SELECT 1 FROM character_pet WHERE owner = {}", player->GetGUID().GetCounter());
+        
+        bool trackTamed = sConfigMgr->GetOption<bool>("BeastMaster.TrackTamedPets", false);
+        QueryResult res2;
+        if (trackTamed) {
+            res2 = CharacterDatabase.Query(
+                "SELECT 1 FROM beastmaster_tamed_pets WHERE owner_guid = {}", player->GetGUID().GetCounter());
+        }
+
+        if (res || res2) {
+            // Delete from DB to prevent duplicate key errors on save. The core marked these as 
+            // removed in-memory during load but hasn't deleted them from the DB yet.
+            CharacterDatabase.Execute(
+                "DELETE FROM character_spell WHERE guid = {} AND spell IN "
+                "(883, 982, 2641, 6991, 48990, 1002, 1462, 6197, 53270)",
+                player->GetGUID().GetCounter());
+
+            for (uint32 spell : HunterSpells) {
+                if (!player->HasSpell(spell)) {
+                    player->learnSpell(spell, false);
+                }
+            }
+
+            if (sConfigMgr->GetOption<bool>("BeastMaster.AllowExotic", false) || 
+                player->HasTalent(PET_SPELL_BEAST_MASTERY, player->GetActiveSpec())) {
+                if (!player->HasSpell(PET_SPELL_BEAST_MASTERY)) {
+                    player->learnSpell(PET_SPELL_BEAST_MASTERY, false);
+                }
+            }
+        }
+      }
+    }
+
     if (!sConfigMgr->GetOption<bool>("BeastMaster.ShowLoginNotice", true))
       return;
 


### PR DESCRIPTION
closes https://github.com/azerothcore/mod-npc-beastmaster/issues/75

### **Overview**

This PR addresses several critical issues in the `mod-npc-beastmaster` module that caused creature spawning failures and the loss of hunter abilities for non-hunter classes upon re-logging.

### **Changes Made**

#### **1. Resolved Action ID Collision for Spawning**

* **Issue:** The module used a small offset (`PET_PAGE_MAX = 901`) to generate Action IDs for spawning pets. This caused a collision with the "Tracked Pets" menu system (reserved range 1000–4999), causing spawn requests to fail or be misinterpreted as pet management commands.
* **Fix:** Introduced `PET_CREATE_OFFSET = 100000`. This ensures that dynamically generated Action IDs for pet creation remain well outside the range of static menu actions.

#### **2. Fixed Spell Retention & Database Integrity**

* **Issue:** Non-hunter classes had their pet-related spells (e.g., Call Pet, Feed Pet) stripped by the core's spell validation during login. Subsequent attempts to re-teach these spells caused `[1062] Duplicate entry` SQL errors in the `character_spell` table because old entries were not being properly cleared.
* **Fix:** Updated the login logic to manually clear existing hunter spell entries from the database before re-teaching them, ensuring a clean state and preventing crashes/errors in the `ac-worldserver` logs.

#### **3. Corrected Script Hook Registration**

* **Issue:** The module was using an outdated/incorrect function signature `OnLogin(Player* player)`. Because it lacked the `override` keyword, it failed silently and was never actually executed by the AzerothCore engine.
* **Fix:** Renamed the function to the modern `OnPlayerLogin` signature and properly registered the `PLAYERHOOK_ON_LOGIN` hook. Added the `override` keyword to prevent future regressions.

### **Testing Performed**

* **Spawning:** Verified that all creatures in the NPC list now spawn correctly without being blocked by menu collisions.
* **Persistence:** Confirmed that non-hunter classes (specifically tested on Rogue) retain all necessary pet management abilities after logging out and back in.
* **Stability:** Verified that the `[1062]` Duplicate entry SQL errors no longer appear in the server console during logout.
* **Compilation:** The module now compiles successfully at 100% with the correct function overrides.

---

### **Note to Maintainer**

Included in this PR is a detailed chat transcript (`Beastmaster Mod Fix - Chat.md`) documenting the AI-assisted debugging process used to identify the logic collisions and the modernization of the `PlayerScript` hooks.

[Beastmaster Mod Fix - Chat.md](https://github.com/user-attachments/files/27580463/Beastmaster.Mod.Fix.-.Chat.md)
